### PR TITLE
Allow administrators to configure the default tracker

### DIFF
--- a/app/controllers/wbs_controller.rb
+++ b/app/controllers/wbs_controller.rb
@@ -4,6 +4,7 @@ class WbsController < ApplicationController
 
   before_action :ensure_rest_api_is_available
   before_action :find_optional_project
+  before_action :build_default_tracker_id
   accept_api_auth :index
 
   def index
@@ -25,5 +26,22 @@ class WbsController < ApplicationController
     return if Setting.rest_api_enabled == "1"
 
     render :template => 'wbs/rest_api_is_unavailable', :status => 403
+  end
+
+  def build_default_tracker_id
+    allowed_tracker_ids = @project.tracker_ids
+
+    if allowed_tracker_ids.include? RedmineWbs.default_tracker_id
+      @default_tracker_id = RedmineWbs.default_tracker_id
+      return
+    end
+
+    unless allowed_tracker_ids.any?
+      render_error :message => l(:error_no_tracker_allowed_for_new_issue_in_project), :status => 403
+
+      return false
+    end
+
+    @default_tracker_id = allowed_tracker_ids.first
   end
 end

--- a/app/views/settings/wbs/_general.html.erb
+++ b/app/views/settings/wbs/_general.html.erb
@@ -1,0 +1,4 @@
+<p>
+  <label><%= l(:label_default_tracker) %></label>
+  <%= select_tag 'settings[default_tracker]', options_for_select(Tracker.all.map{|tr| [tr.name, tr.id]}, RedmineWbs.default_tracker_id) %>
+</p>

--- a/app/views/wbs/_list.html.erb
+++ b/app/views/wbs/_list.html.erb
@@ -2,7 +2,7 @@
   <%= hidden_field_tag 'back_url', url_for(:params => request.query_parameters), :id => nil %>
 
   <div class="autoscroll">
-    <wbs-issues project-id="<%= project.id %>">
+    <wbs-issues project-id="<%= project.id %>" default-tracker-id="<%= default_tracker_id %>">
       <template slot="header">
         <th class="checkbox hide-when-print">
           <%= check_box_tag 'check_all', '', false, :class => 'toggle-selection', :title => "#{l(:button_check_all)}/#{l(:button_uncheck_all)}" %>

--- a/app/views/wbs/index.html.erb
+++ b/app/views/wbs/index.html.erb
@@ -1,6 +1,6 @@
 <h2><%= l(:label_wbs) %></h2>
 
-<%= render :partial => 'wbs/list', :locals => { :project => @project } %>
+<%= render :partial => 'wbs/list', :locals => { :project => @project, :default_tracker_id => @default_tracker_id } %>
 
 <%= call_hook(:view_wbs_index_bottom, { :project => @project }) %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,6 @@
 # English strings go here for Rails i18n
 en:
   label_wbs: WBS
+  label_default_tracker: Default tracker
   project_module_wbs: WBS
   text_rest_api_unavailable: "Redmine REST API is required to use this tool. Please verify that it’s enabled and that your user has an API token."

--- a/init.rb
+++ b/init.rb
@@ -12,6 +12,9 @@ Redmine::Plugin.register :redmine_wbs do
 
   requires_redmine :version_or_higher => '2.3'
 
+  settings :default => {},
+           :partial => 'settings/wbs/general'
+
   menu :project_menu, :wbs, { :controller => 'wbs', :action => 'index' }, :caption => :label_wbs, :before => :gantt, :param => :project_id
 
   project_module :wbs do

--- a/lib/redmine_wbs.rb
+++ b/lib/redmine_wbs.rb
@@ -1,0 +1,7 @@
+module RedmineWbs
+  class << self
+    def default_tracker_id
+      Setting.plugin_redmine_wbs['default_tracker'].to_i
+    end
+  end
+end

--- a/resources/js/components/WbsIssues.vue
+++ b/resources/js/components/WbsIssues.vue
@@ -113,7 +113,7 @@
           level,
           project_id: this.projectId,
           subject: '',
-          tracker_id: 1, // TODO: Change me... do we need to insert a dynamic value here?
+          tracker_id: this.defaultTrackerId,
           local_key: this.newLocalKey(),
         };
 
@@ -176,6 +176,10 @@
 
     props: {
       projectId: {
+        type: String,
+        required: true,
+      },
+      defaultTrackerId: {
         type: String,
         required: true,
       }

--- a/test/functional/wbs_controller_test.rb
+++ b/test/functional/wbs_controller_test.rb
@@ -6,11 +6,13 @@ class WbsControllerTest < ActionController::TestCase
            :roles,
            :members,
            :member_roles,
+           :issues,
+           :issue_statuses,
+           :trackers,
+           :projects_trackers,
+           :issue_categories,
            :enabled_modules,
-           :enumerations,
-           :repositories,
-           :changesets,
-           :changes
+           :enumerations
 
   def setup
     # Enable the REST API


### PR DESCRIPTION
# Description

This PR add a configuration page to the plugin to allow administrators to configure the default tracker used when creating an issue with the WBS plugin.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

With manual tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
