### PR TITLE
Fix Configure which trackers are displayed #11

### DIFF
--- a/app/controllers/wbs_controller.rb
+++ b/app/controllers/wbs_controller.rb
@@ -5,6 +5,7 @@ class WbsController < ApplicationController
   before_action :ensure_rest_api_is_available
   before_action :find_optional_project
   before_action :build_default_tracker_id
+  before_action :build_excluded_tracker_ids
   accept_api_auth :index
 
   def index
@@ -13,10 +14,20 @@ class WbsController < ApplicationController
         render :layout => !request.xhr?
       }
       format.api  {
-        @issues = @project.issues.visible
-                    .where
-                      .not(tracker_id: RedmineWbs.excluded_tracker_ids.reject { |c| c.empty? })
-                    .order("#{Issue.table_name}.root_id ASC, #{Issue.table_name}.lft ASC")
+        query = "
+          SELECT I.*
+            FROM issues I
+           WHERE I.`project_id` = ?
+             AND I.`root_id` NOT IN (
+              SELECT I.`id`
+                FROM `issues` I
+                JOIN `trackers` T ON t.`id` = I.`tracker_id`
+               WHERE I.`root_id` = I.`id` AND I.`tracker_id` IN (?) OR T.`fields_bits` & 64
+            )
+          ORDER BY I.`root_id` ASC, I.`lft` ASC
+        "
+
+        @issues = Issue.find_by_sql([query, @project.id, @excluded_tracker_ids])
       }
     end
   rescue ActiveRecord::RecordNotFound
@@ -46,5 +57,9 @@ class WbsController < ApplicationController
     end
 
     @default_tracker_id = allowed_tracker_ids.first
+  end
+
+  def build_excluded_tracker_ids
+    @excluded_tracker_ids = RedmineWbs.excluded_tracker_ids.reject { |item| item.empty? }.join(',')
   end
 end

--- a/app/controllers/wbs_controller.rb
+++ b/app/controllers/wbs_controller.rb
@@ -13,7 +13,10 @@ class WbsController < ApplicationController
         render :layout => !request.xhr?
       }
       format.api  {
-        @issues = @project.issues.visible.order("#{Issue.table_name}.root_id ASC, #{Issue.table_name}.lft ASC")
+        @issues = @project.issues.visible
+                    .where
+                      .not(tracker_id: RedmineWbs.excluded_tracker_ids.reject { |c| c.empty? })
+                    .order("#{Issue.table_name}.root_id ASC, #{Issue.table_name}.lft ASC")
       }
     end
   rescue ActiveRecord::RecordNotFound

--- a/app/controllers/wbs_controller.rb
+++ b/app/controllers/wbs_controller.rb
@@ -5,7 +5,6 @@ class WbsController < ApplicationController
   before_action :ensure_rest_api_is_available
   before_action :find_optional_project
   before_action :build_default_tracker_id
-  before_action :build_excluded_tracker_ids
   accept_api_auth :index
 
   def index
@@ -14,20 +13,7 @@ class WbsController < ApplicationController
         render :layout => !request.xhr?
       }
       format.api  {
-        query = "
-          SELECT I.*
-            FROM issues I
-           WHERE I.`project_id` = ?
-             AND I.`root_id` NOT IN (
-              SELECT I.`id`
-                FROM `issues` I
-                JOIN `trackers` T ON t.`id` = I.`tracker_id`
-               WHERE I.`root_id` = I.`id` AND I.`tracker_id` IN (?) OR T.`fields_bits` & 64
-            )
-          ORDER BY I.`root_id` ASC, I.`lft` ASC
-        "
-
-        @issues = Issue.find_by_sql([query, @project.id, @excluded_tracker_ids])
+        @issues = WbsQuery.new(@project).issues
       }
     end
   rescue ActiveRecord::RecordNotFound
@@ -57,9 +43,5 @@ class WbsController < ApplicationController
     end
 
     @default_tracker_id = allowed_tracker_ids.first
-  end
-
-  def build_excluded_tracker_ids
-    @excluded_tracker_ids = RedmineWbs.excluded_tracker_ids.reject { |item| item.empty? }.join(',')
   end
 end

--- a/app/models/wbs_query.rb
+++ b/app/models/wbs_query.rb
@@ -1,0 +1,35 @@
+class WbsQuery
+  def initialize(project)
+    @project = project
+  end
+
+  def issues
+    Issue
+      .where(root_id: visible_root_issues)
+      .order("#{Issue.table_name}.root_id ASC, #{Issue.table_name}.lft ASC")
+  end
+
+  def issue_count
+    issues.count
+  end
+
+  private
+
+  def visible_root_issues
+    Issue
+      .select(:id)
+      .visible
+      .where("#{Issue.table_name}.root_id = #{Issue.table_name}.id")
+      .where(project_id: @project.id)
+      .where.not(tracker_id: valid_trackers)
+  end
+
+  def valid_trackers
+    Tracker.select(:id)
+      .where(
+        "#{Tracker.table_name}.id IN (?) OR #{Tracker.table_name}.fields_bits & ?",
+        RedmineWbs.excluded_tracker_ids,
+        RedmineWbs.required_core_field_bits
+      )
+  end
+end

--- a/app/views/settings/wbs/_general.html.erb
+++ b/app/views/settings/wbs/_general.html.erb
@@ -2,3 +2,8 @@
   <label><%= l(:label_default_tracker) %></label>
   <%= select_tag 'settings[default_tracker]', options_for_select(Tracker.all.map{|tr| [tr.name, tr.id]}, RedmineWbs.default_tracker_id) %>
 </p>
+
+<p>
+  <label><%= l(:label_excluded_tracker) %></label>
+  <%= select_tag 'settings[excluded_tracker]', options_for_select(Tracker.all.map{|tr| [tr.name, tr.id]}, RedmineWbs.excluded_tracker_ids), :multiple => true, :include_blank => true, :size => 10, :style => "width:150px" %>
+</p>

--- a/app/views/settings/wbs/_general.html.erb
+++ b/app/views/settings/wbs/_general.html.erb
@@ -5,5 +5,5 @@
 
 <p>
   <label><%= l(:label_excluded_tracker) %></label>
-  <%= select_tag 'settings[excluded_tracker]', options_for_select(Tracker.all.map{|tr| [tr.name, tr.id]}, RedmineWbs.excluded_tracker_ids), :multiple => true, :include_blank => true, :size => 10, :style => "width:150px" %>
+  <%= select_tag 'settings[excluded_tracker]', options_for_select(Tracker.all.map{|tr| [tr.name, tr.id]}, RedmineWbs.excluded_tracker_ids), :multiple => true, :size => 10, :style => "width:150px" %>
 </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,5 +2,6 @@
 en:
   label_wbs: WBS
   label_default_tracker: Default tracker
+  label_excluded_tracker: Excluded tracker
   project_module_wbs: WBS
   error_rest_api_unavailable: "Redmine REST API is required to use this tool. Please verify that it’s enabled and that your user has an API token."

--- a/lib/redmine_wbs.rb
+++ b/lib/redmine_wbs.rb
@@ -7,5 +7,9 @@ module RedmineWbs
     def excluded_tracker_ids
       Setting.plugin_redmine_wbs['excluded_tracker'] || []
     end
+
+    def required_core_field_bits
+      64 # is for 2^6 which is corresponding to "Estimated time" in trackers settings
+    end
   end
 end

--- a/lib/redmine_wbs.rb
+++ b/lib/redmine_wbs.rb
@@ -2,6 +2,10 @@ module RedmineWbs
   class << self
     def default_tracker_id
       Setting.plugin_redmine_wbs['default_tracker'].to_i
+      end
+
+    def excluded_tracker_ids
+      Setting.plugin_redmine_wbs['excluded_tracker']
     end
   end
 end

--- a/lib/redmine_wbs.rb
+++ b/lib/redmine_wbs.rb
@@ -5,7 +5,7 @@ module RedmineWbs
       end
 
     def excluded_tracker_ids
-      Setting.plugin_redmine_wbs['excluded_tracker']
+      Setting.plugin_redmine_wbs['excluded_tracker'] || []
     end
   end
 end

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -28,7 +28,7 @@ if (token) {
 
 const userApiKey = document.head.querySelector('meta[name="user-api-key"]');
 
-if (token) {
+if (userApiKey) {
   axios.defaults.headers.common['X-Redmine-API-Key'] = userApiKey.content;
 } else {
   console.error('User API key not found!');


### PR DESCRIPTION
# Description
Add a new configuration in the plugin settings page in order to be able to choose excluded trackers for the whole Redmine.

Fixes #11

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
1. Go in the [plugin settings page](settings/plugin/redmine_wbs)
1. Select `Excluded tracker` you want to test
1. Choose a project and go under `WBS` tab

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests pass locally with my changes
- [ ] ~Any dependent changes have been merged and published in downstream modules~
